### PR TITLE
Introduce app history service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## Unreleased
+- Introduce appHistory service. Update custom request lib. Update routes helper
+([#42](https://github.com/fs/react-base/pull/42))
 - Extract session actions into session service
-([#40](https://github.com/fs/react-base/pull/40))
+([#41](https://github.com/fs/react-base/pull/41))
 - Add new rules in postcss sorting config
 ([#39](https://github.com/fs/react-base/pull/39))
 - Upgrade Node.js to 6.3.x

--- a/app/application.jsx
+++ b/app/application.jsx
@@ -1,15 +1,16 @@
 import 'stylesheets/application';
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, Route, Redirect, browserHistory } from 'react-router';
+import { Router, Route, Redirect } from 'react-router';
+import { appHistory } from 'services/history';
+import { requireAuth } from 'helpers/routes';
 import Application from 'components/application';
 import Main from 'components/main';
 import About from 'components/about';
 import Article from 'components/article';
-import { requireAuth } from 'helpers/routes';
 
 render((
-  <Router history={ browserHistory }>
+  <Router history={ appHistory }>
     <Route component={ Application }>
       <Route path="/" component={ Main }/>
       <Route

--- a/app/components/about/index.jsx
+++ b/app/components/about/index.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Grid } from 'react-bootstrap';
+import { paths } from 'helpers/routes';
 
 export default class About extends React.Component {
+  id = 'test_id'
+
   render() {
     return (
       <Grid>
@@ -11,7 +14,7 @@ export default class About extends React.Component {
           <p>
             Kick-start your new web application based on React and Flux technologies.
           </p>
-          <Link to="/about/extended/test_id">
+          <Link to={ paths.aboutExtended(this.id) }>
             show details...
           </Link>
           { this.props.children }

--- a/app/components/header/index.jsx
+++ b/app/components/header/index.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import { Navbar } from 'react-bootstrap';
 import NavigationLeft from 'components/navigation/left';
 import NavigationRight from 'components/navigation/right';
+import { paths } from 'helpers/routes';
 
 export default class Header extends React.Component {
   render() {
     const links = [
-      { title: 'Home', route: '/' },
-      { title: 'About', route: '/about' }
+      { title: 'Home', route: paths.home() },
+      { title: 'About', route: paths.about() }
     ];
 
     return (

--- a/app/helpers/routes.js
+++ b/app/helpers/routes.js
@@ -1,5 +1,11 @@
 import session from 'services/session';
 
+export const paths = {
+  home() { return '/'; },
+  about() { return '/about'; },
+  aboutExtended(id) { return `/about/extended/${id}`; }
+};
+
 export function requireAuth(nextState, replace) {
   if (!session.loggedIn()) {
     replace({

--- a/app/lib/request.js
+++ b/app/lib/request.js
@@ -5,7 +5,9 @@ import deepAssign from 'deep-assign';
 import { pickBy } from 'lodash';
 
 function filteredParams(params) {
-  return qs.stringify(pickBy(params, item => !!item));
+  const filteredParams = pickBy(params, item => !!item);
+
+  return `?${qs.stringify(filteredParams, { arrayFormat: 'brackets' })}`;
 }
 
 export function request(url, params, queryParams) {
@@ -17,7 +19,7 @@ export function request(url, params, queryParams) {
   };
 
   if (queryParams) {
-    url += `?${filteredParams(queryParams)}`;
+    url += filteredParams(queryParams);
   }
 
   return fetch(url, deepAssign({}, defaultParams, params));

--- a/app/services/history.js
+++ b/app/services/history.js
@@ -1,0 +1,10 @@
+import { useRouterHistory } from 'react-router';
+import createBrowserHistory from 'history/lib/createBrowserHistory';
+import qs from 'qs';
+
+const createAppHistory = useRouterHistory(createBrowserHistory);
+
+export const appHistory = createAppHistory({
+  parseQueryString: qs.parse,
+  stringifyQuery: qs.stringify
+});


### PR DESCRIPTION
- This service is necessary to avoid a lot of issues connected with statement save logic in browser url. Default `browserHistory` can not save deep objects and arrays. This service add custom methods via `qs` `parse/stringify` that allow us to do it.
